### PR TITLE
Remove long_schedule platform define

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {erl_opts, [debug_info,
             fail_on_warning,
-            {platform_define, "R16B01|R16B02|R16B03|^[0-9]+", long_schedule},
             {parse_transform, lager_transform}]}.
 
 {eunit_opts, [verbose]}.
@@ -12,6 +11,6 @@
         {cuttlefish, ".*", {git, "https://github.com/tsloughter/cuttlefish.git", {branch, "develop"}}}
        ]}]}]}.
 
-{plugins, [rebar_erl_vsn]}.
+{plugins, [{rebar_erl_vsn, "~>0.1.7"}]}.
 {provider_hooks, [{pre, [{compile, erl_vsn}]}]}.
 


### PR DESCRIPTION
with 0.1.7 this is provided by the `rebar_erl_vsn` plugin, not having the same defines in many places is a lot cleaner.